### PR TITLE
Error when interpolating a map property

### DIFF
--- a/test/ex_twiml_test.exs
+++ b/test/ex_twiml_test.exs
@@ -1,5 +1,5 @@
 defmodule ExTwimlTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import ExTwiml
 
   test "Can render the <Gather> verb" do
@@ -190,6 +190,18 @@ defmodule ExTwimlTest do
     end
 
     assert opts == [{1, []}, {2, []}, {3, []}]
+  end
+
+  test ".twiml can loop through lists of maps" do
+    people = [%{name: "Daniel"}, %{name: "Hunter"}]
+
+    xml = twiml do
+      Enum.each people, fn person ->
+        say "Hello, #{person.name}!"
+      end
+    end
+
+    assert_twiml xml, "<Say>Hello, Daniel!</Say><Say>Hello, Hunter!</Say>"
   end
 
   defp assert_twiml(lhs, rhs) do


### PR DESCRIPTION
If you interpolate a map property in a verb, like this:

``` elixir
people = [%{name: "Daniel"}, %{name: "Hunter"}]

twiml do
  Enum.each people, fn person ->
    say "Hello, #{person.name}!"
  end
end
```

You'll get an error. This is because of a funky thing with macro generation, where it tries to figure out if the argument passed into `say` is a string or not. Since it contains an interpolation, it tries to execute the interpolation, but in the wrong context, where the `person.name` binding is not set.

Instead, it should pattern match for `:<<>>>`.
