### PR TITLE
Bugfix: Allow using a variable as only argument to verb

### DIFF
--- a/lib/ex_twiml.ex
+++ b/lib/ex_twiml.ex
@@ -188,7 +188,7 @@ defmodule ExTwiml do
       case string_or_options do
         string when is_binary(string) ->
           compile_string_macro(unquote(verb), options, string)
-        {:<<>>, _, _} ->
+        {atom, _, _} when is_atom(atom) ->
           compile_string_macro(unquote(verb), options, string_or_options)
         _ ->
           compile_nested_macro(unquote(verb), string_or_options)

--- a/test/ex_twiml_test.exs
+++ b/test/ex_twiml_test.exs
@@ -204,6 +204,15 @@ defmodule ExTwimlTest do
     assert_twiml xml, "<Say>Hello, Daniel!</Say><Say>Hello, Hunter!</Say>"
   end
 
+  test ".twiml can 'say' a variable that happens to be a string" do
+    some_var = "hello world"
+    markup = twiml do
+      say some_var
+    end
+
+    assert_twiml markup, "<Say>hello world</Say>"
+  end
+
   defp assert_twiml(lhs, rhs) do
     assert lhs == "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Response>#{rhs}</Response>"
   end

--- a/test/ex_twiml_test.exs
+++ b/test/ex_twiml_test.exs
@@ -183,7 +183,7 @@ defmodule ExTwimlTest do
   end
 
   test ".twiml can include Enum loops" do
-    {opts, _xml} = twiml do
+    {opts, _markup} = twiml do
       Enum.each 1..3, fn(n) ->
         option n, "Press #{n}"
       end
@@ -195,13 +195,13 @@ defmodule ExTwimlTest do
   test ".twiml can loop through lists of maps" do
     people = [%{name: "Daniel"}, %{name: "Hunter"}]
 
-    xml = twiml do
+    markup = twiml do
       Enum.each people, fn person ->
         say "Hello, #{person.name}!"
       end
     end
 
-    assert_twiml xml, "<Say>Hello, Daniel!</Say><Say>Hello, Hunter!</Say>"
+    assert_twiml markup, "<Say>Hello, Daniel!</Say><Say>Hello, Hunter!</Say>"
   end
 
   test ".twiml can 'say' a variable that happens to be a string" do


### PR DESCRIPTION
Right now, this code does not work:

```
some_var = "Hello, World!"
twiml do
  say some_var
end
```

This commit patches the issue.
