### PR TITLE
Feature: allow nested verbs without options

### DIFF
--- a/lib/ex_twiml.ex
+++ b/lib/ex_twiml.ex
@@ -135,7 +135,7 @@ defmodule ExTwiml do
           end
         end
     """
-    defmacro unquote(verb)(options, do: inner) do
+    defmacro unquote(verb)(options \\ [], do: inner) do
       current_verb = unquote(verb)
 
       quote do

--- a/test/ex_twiml_test.exs
+++ b/test/ex_twiml_test.exs
@@ -2,7 +2,7 @@ defmodule ExTwimlTest do
   use ExUnit.Case, async: false
   import ExTwiml
 
-  test "Can render the <Gather> verb" do
+  test "can render the <Gather> verb" do
     markup = twiml do
       gather digits: 3 do
         text "Phone Number"
@@ -10,6 +10,16 @@ defmodule ExTwimlTest do
     end
 
     assert_twiml markup, "<Gather digits=\"3\">Phone Number</Gather>"
+  end
+
+  test "can render the <Gather> verb without any options" do
+    markup = twiml do
+      gather do
+        text "Phone Number"
+      end
+    end
+
+    assert_twiml markup, "<Gather>Phone Number</Gather>"
   end
 
   test "can render the <Say> verb" do


### PR DESCRIPTION
Allow calling nested verb macros like this:

```
twiml do
  gather do
    say "..."
  end
end
```

Rather than only like this:

```
twiml do
  gather finish_on_key: "#" do
    say "..."
  end
end
```
