### PR TITLE
Clean up utilities module

### DIFF
--- a/lib/ex_twiml.ex
+++ b/lib/ex_twiml.ex
@@ -133,9 +133,9 @@ defmodule ExTwiml do
   """
   defmacro tag(name, options \\ [], do: inner) do
     quote do
-      put_buffer var!(buffer, Twiml), opening_tag(unquote(name), "", unquote(options))
+      put_buffer var!(buffer, Twiml), create_tag(:opening, unquote(name), unquote(options))
       unquote(inner)
-      put_buffer var!(buffer, Twiml), closing_tag(unquote(name))
+      put_buffer var!(buffer, Twiml), create_tag(:closing, unquote(name))
     end
   end
 
@@ -236,7 +236,7 @@ defmodule ExTwiml do
   defp compile_empty(verb, options \\ []) do
     quote do
       # Render only a single tag, with options
-      put_buffer var!(buffer, Twiml), opening_tag(unquote(verb), " /", unquote(options))
+      put_buffer var!(buffer, Twiml), create_tag(:self_closed, unquote(verb), unquote(options))
     end
   end
 end

--- a/test/ex_twiml/utilities_test.exs
+++ b/test/ex_twiml/utilities_test.exs
@@ -2,25 +2,19 @@ defmodule ExTwiml.UtilitiesTest do
   use ExUnit.Case
   import ExTwiml.Utilities
 
-  test ".opening_tag creates an opening XML tag" do
-    assert opening_tag(:address, "/") == "<Address/>"
-  end
-
-  test ".closing_tag closes a tag" do
-    assert closing_tag(:address) == "</Address>"
-  end
+  doctest ExTwiml.Utilities
 
   test ".generate_xml_attributes converts a keyword list into XML attributes" do
     options = [finish_on_key: "#", digits: 1]
     assert xml_attributes(options) == " finishOnKey=\"#\" digits=\"1\""
   end
 
-  test ".to_camel_case converts an underscore string into headless camel case" do
-    assert to_camel_case(:some_random_string) == "someRandomString"
+  test ".camelize converts an underscore string into headless camel case" do
+    assert camelize(:some_random_string) == "someRandomString"
   end
 
-  test ".to_camel_case does not modify a string already in headless camel case" do
-    assert to_camel_case(:someRandomString) == "someRandomString"
+  test ".camelize does not modify a string already in headless camel case" do
+    assert camelize(:someRandomString) == "someRandomString"
   end
 
   test ".capitalize capitalizes strings and atoms" do


### PR DESCRIPTION
Simplify the tag generation function, delegate most of the camelization
logic to Mix.Utils.camelize. Add some doctests.
