### PR TITLE
Warn about reserved names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,13 @@
 language: elixir
 elixir:
-  - 1.0.3
-  - 1.0.4
+  - 1.1.1
 otp_release:
-  - 17.4
+  - 18.0
 before_script:
-  - export PATH=`pwd`/elixir/bin:$PATH
-  - export PLT_FILENAME=elixir-${TRAVIS_ELIXIR_VERSION}_$TRAVIS_OTP_RELEASE.plt
-  - export PLT_LOCATION=/home/travis/$PLT_FILENAME
-  - wget -O $PLT_LOCATION https://raw.github.com/danielberkompas/travis_elixir_plts/master/$PLT_FILENAME
   - mix local.hex --force
   - mix deps.get --only test
 script:
   - mix test
-  - dialyzer --no_check_plt --plt $PLT_LOCATION -Wno_match -Wno_return --no_native _build/test/lib/ex_twiml/ebin
 after_script:
-- MIX_ENV=docs mix deps.get
-- MIX_ENV=docs mix inch.report
+  - MIX_ENV=docs mix deps.get
+  - MIX_ENV=docs mix inch.report

--- a/lib/ex_twiml/reserved_name_error.ex
+++ b/lib/ex_twiml/reserved_name_error.ex
@@ -17,6 +17,7 @@ defmodule ExTwiml.ReservedNameError do
   defexception [:message]
 
   @doc false
+  @spec exception(list) :: %__MODULE__{}
   def exception([{name, context, _}, file_name]) do
     file_name = Path.relative_to_cwd(file_name)
     name = to_string(name)

--- a/lib/ex_twiml/reserved_name_error.ex
+++ b/lib/ex_twiml/reserved_name_error.ex
@@ -1,0 +1,33 @@
+defmodule ExTwiml.ReservedNameError do
+  @moduledoc """
+  This error is thrown if you try to use TwiML verb name as a variable name
+  in your `twiml` block.
+
+  ## Example
+
+  This code will raise the error, because `number` is a reserved name.
+
+      twiml do
+        Enum.each [1, 2], fn(number) ->
+          # ...
+        end
+      end
+  """
+
+  defexception [:message]
+
+  @doc false
+  def exception([{name, context, _}, file_name]) do
+    file_name = Path.relative_to_cwd(file_name)
+    name = to_string(name)
+
+    message = ~s"""
+    "#{name}" is a reserved name in #{file_name}:#{context[:line]}, because it
+    is used to generate the <#{String.capitalize(name)} /> TwiML verb.
+
+    Please use a different variable name.
+    """
+
+    %__MODULE__{message: message}
+  end
+end

--- a/test/ex_twiml/reserved_name_error_test.exs
+++ b/test/ex_twiml/reserved_name_error_test.exs
@@ -1,0 +1,17 @@
+defmodule ExTwiml.ReservedNameErrorTest do
+  use ExUnit.Case
+
+  alias ExTwiml.ReservedNameError
+
+  test ".exception returns a nice exception" do
+    %{message: message} = ReservedNameError.exception([{:number, [line: 1], []},
+                                                      "test/test.ex"])
+
+    assert message == ~s"""
+    "number" is a reserved name in test/test.ex:1, because it
+    is used to generate the <Number /> TwiML verb.
+
+    Please use a different variable name.
+    """
+  end
+end

--- a/test/ex_twiml_test.exs
+++ b/test/ex_twiml_test.exs
@@ -1,6 +1,9 @@
 defmodule ExTwimlTest do
   use ExUnit.Case, async: false
+
   import ExTwiml
+
+  alias ExTwiml.ReservedNameError
 
   doctest ExTwiml
 
@@ -224,6 +227,21 @@ defmodule ExTwimlTest do
     end
 
     assert_twiml markup, "<Say>123</Say>"
+  end
+
+  test ".twiml warns of reserved variable names" do
+    ast = quote do
+      twiml do
+        Enum.each [1, 2], fn(number) ->
+          say "#{number}"
+        end
+      end
+    end
+
+    assert_raise ReservedNameError, fn ->
+      # Simulate compiling the macro
+      Macro.expand(ast, __ENV__)
+    end
   end
 
   defp assert_twiml(lhs, rhs) do


### PR DESCRIPTION
As mentioned in #10, you cannot use a TwiML verb name as a parameter in
a function definition, like this:

``` elixir
Enum.each [1, 2] fn(number) ->
  say "Press #{number}"
end
```

This commit adds a nice warning message if a user attempts to do this,
telling them that the "number" verb is reserved.
