### PR TITLE
Support variables in verb options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 
-## [v2.0.1](https://github.com/danielberkompas/ex_twiml/tree/v2.0.1) (2015-12-14)
-[Full Changelog](https://github.com/danielberkompas/ex_twiml/compare/v2.0.0...v2.0.1)
+## [Unreleased](https://github.com/danielberkompas/ex_twiml/tree/HEAD)
+
+[Full Changelog](https://github.com/danielberkompas/ex_twiml/compare/v2.0.0...HEAD)
 
 **Closed issues:**
 

--- a/SIGNED.md
+++ b/SIGNED.md
@@ -3,19 +3,19 @@
 -----BEGIN PGP SIGNATURE-----
 Comment: GPGTools - https://gpgtools.org
 
-iQIcBAABCgAGBQJWbv0bAAoJEKU82t1CbYQMbPwP/3EApRyBem+nwJUVoFSFHZeL
-IV4qdNm3o7zFuK/0YHOxVxvDCiEAL73fOc6oyu1DLRrz9OjFJf5zlU21aTzNXUPo
-tn19up1k+by0Z6Da84bBjEWV8Iq4Q/QhH0a2IzKQyNb54Vr1UVHJztmrrsvLdxpD
-grDKGbozjmC0WqAXwrbrTYMy7kejFIt56rJ/K09Ov2VVFFndQbTVgnKlG5D5eiLy
-51llttlONCqV+otAlaIwRAR+pUMS/J3/kH7qENz45u6jm+/j4yaYfGan/l6YXR+r
-MpxBkc+OZz6MnnEQowUmEaBeKR/2MRuMKOgLSUBwWnrs/ie0cbEh8+oUt69I2MeD
-46PoNP6M3CJW340B6l1XF4A4eYXfJ+rCA31u6kdra1+ZbycItlxStOZODQtF2ZSc
-fkZlZ67iY7D6Lrf3OIggyQSVBQ+JixL8PWsMIGpxWaGYI+lBj5AxQ07KwPBBtA6X
-uUeCQqb8vMeYc9JZhk+JgNufBoorHGitRaFlaXcHOg/dji9BKEMZ24xIXU3gubL/
-cbop2saz5Dav4pN+32CSVdMCbgvJ67FJAARvD/dif1Lq6hIA6PBijC+0EaVARTGM
-Iyu3v4ixr13hFO8BRor2fFYhFtR+IqqiqT71NTLfipnHBLUgpkFan02I1+m3xqs+
-JZd/+PoBACE7HOFMAtJK
-=gPQ6
+iQIcBAABCgAGBQJWbv7JAAoJEKU82t1CbYQMk2YP+wfyy/nr2kkCwWlPuPf72IFx
+fkmHAAbL4dHeHXHEsh567vpSQHMx5rhlrGeDDGe32JlEc+UDS73lU9lig+CrXYnm
+sBaUcvz4pTNMToGLU05eqrkHD11ld1RgF0bj+OyIJJQJ1GFSC1Uo3SpoL70dvY6j
+ULldkkpY2qivkmH2FcHphS2MC/ZMyPkrsHgdSArfRv9bYsvca34ukeCLkjrqVhD2
+CWZx5DIFg7fzirAz/jDqI9OmJtV73LKL5RCi5gW5+se5+4fj/wscvpX2ZiE7GsZ3
+i1BZZIQ1W/7oorhhImyq8phajTXnG0R9XCwmZrPx2LjSde12sxIJz70ntf9vDgwL
+lfpC00faS9K8cay/Ruw6lMiZZ26UpUQvlyLwUZcASqJJ9rhvnnvLWUxYGmgWGQsF
+SANotL0aMIN4+bp0XXqhDFpesH/GRBnlrAsz5CVm9IQ2TPsFtUrWNq8C7lUjvS4z
+fa/y4FjSkjtcTvacSvkw1/hVpgjX/5X56BtXdXEKycJepXhE7zYfmqbewVbBZdPa
+qjWgwZionPa31HnL6Rs+DL1cy0mo4PrYdiJ6vX0ws+OCsRif58D8HC4VWqYduaPj
+9I1hmzrj65/gMLNAjT6MNr3MMGpoLMNouxqhqFOebqQ6QhR1em71V61vmrnGo6A3
+LnmLPDAuXhWA4kOboCr7
+=sruQ
 -----END PGP SIGNATURE-----
 
 ```
@@ -37,7 +37,7 @@ size  exec  file                          contents
 819               reserved_name_error.ex  84adb553bbaba0cc06294f2b0f830d9a6907ada0da029a2fc6980b0efce1b662
 2303              utilities.ex            213e05588339362c187cec619b21655c8c1ebf1c573d1e3b9fa067065b313bbe
 7786            ex_twiml.ex               27024f4039bcba5907c5aeaa4893023a5b609a7acffcbaf6d22d714fd9de82b6
-1403          mix.exs                     f77046b32aa7876d16907901673ff7a2ab0bf4843dc30063b652451bb2126167
+1392          mix.exs                     c819531658050d6b27ae93835686dc59eef11d3638fd2414e1429d4184589000
 ```
 
 #### Ignore

--- a/lib/ex_twiml.ex
+++ b/lib/ex_twiml.ex
@@ -75,8 +75,10 @@ defmodule ExTwiml do
 
     # Non-nested
     :say, :number, :play, :sms, :sip, :client, :conference, :queue, :enqueue,
-    :leave, :hangup, :reject, :pause, :record, :redirect, :body, :media
+    :redirect, :body, :media
   ]
+
+  @simple_verbs [:leave, :hangup, :reject, :pause, :record]
 
   @doc """
   Start creating a TwiML document. Returns the rendered TwiML as a string.
@@ -203,13 +205,8 @@ defmodule ExTwiml do
   end
 
   # {:say, [], ["Hello World", [voice: "woman"]}
-  defp postwalk({verb, _meta, [string, options]}) when verb in @verbs and is_list(options) do
+  defp postwalk({verb, _meta, [string, options]}) when verb in @verbs do
     compile_simple(verb, string, options)
-  end
-
-  # {:pause, [], [[length: 5]]}
-  defp postwalk({verb, _meta, [options]}) when verb in @verbs and is_list(options) do
-    compile_empty(verb, options)
   end
 
   # {:say, [], ["Hello World"]}
@@ -218,8 +215,13 @@ defmodule ExTwiml do
     compile_simple(verb, string)
   end
 
+  # {:pause, [], [[length: 5]]}
+  defp postwalk({verb, _meta, [options]}) when verb in @simple_verbs do
+    compile_empty(verb, options)
+  end
+
   # {:leave, [], Elixir}
-  defp postwalk({verb, _meta, _args}) when verb in @verbs do
+  defp postwalk({verb, _meta, _args}) when verb in @simple_verbs do
     compile_empty(verb)
   end
 

--- a/test/ex_twiml_test.exs
+++ b/test/ex_twiml_test.exs
@@ -229,6 +229,35 @@ defmodule ExTwimlTest do
     assert_twiml markup, "<Say>123</Say>"
   end
 
+  test ".twiml simple verbs can take options as a variable" do
+    options = [voice: "alice"]
+    markup = twiml do
+      say "I'm Alice", options
+    end
+
+    assert_twiml markup, "<Say voice=\"alice\">I'm Alice</Say>"
+  end
+
+  test ".twiml self-closing verbs can take options as a variable" do
+    options = [length: 31]
+    markup = twiml do
+      pause options
+    end
+
+    assert_twiml markup, "<Pause length=\"31\" />"
+  end
+
+  test ".twiml nested verbs can take options as a variable" do
+    options = [method: "GET"]
+    markup = twiml do
+      gather options do
+        say "Hi"
+      end
+    end
+
+    assert_twiml markup, "<Gather method=\"GET\"><Say>Hi</Say></Gather>"
+  end
+
   test ".twiml warns of reserved variable names" do
     ast = quote do
       twiml do


### PR DESCRIPTION
This allows you to do this:

``` elixir
options = [voice: "alice"] 

twiml do
  say "Something", options 
end
```

It's a lot easier to share configs between multiple `<Say>` verbs, for
example.
