### PR TITLE
task verb and tests

### DIFF
--- a/lib/ex_twiml.ex
+++ b/lib/ex_twiml.ex
@@ -71,7 +71,7 @@ defmodule ExTwiml do
 
   @verbs [
     # Nested
-    :gather, :dial, :message,
+    :gather, :dial, :message, :task,
 
     # Non-nested
     :say, :number, :play, :sms, :sip, :client, :conference, :queue, :enqueue,

--- a/test/ex_twiml_test.exs
+++ b/test/ex_twiml_test.exs
@@ -80,7 +80,7 @@ defmodule ExTwimlTest do
   test "can render the <Sip> verb" do
     markup = twiml do
       sip "sip:test@example.com", username: "admin", password: "123"
-    end 
+    end
 
     assert_twiml markup, "<Sip username=\"admin\" password=\"123\">sip:test@example.com</Sip>"
   end
@@ -116,6 +116,24 @@ defmodule ExTwimlTest do
     end
 
     assert_twiml markup, "<Enqueue waitUrl=\"wait-music.xml\">support</Enqueue>"
+  end
+
+  test "can render the <Task> verb" do
+    markup = twiml do
+      task ~s({"selected_language": "it"})
+    end
+
+    assert_twiml markup, ~s(<Task>{"selected_language": "it"}</Task>)
+  end
+
+  test "can render the <Task> verb nested inside an <Enqueue> verb" do
+    markup = twiml do
+      enqueue do
+        task ~s({"selected_language": "it"})
+      end
+    end
+
+    assert_twiml markup, ~s(<Enqueue><Task>{"selected_language": "it"}</Task></Enqueue>)
   end
 
   test "can render the <Leave> verb" do


### PR DESCRIPTION
Hi! Thanks for this library.

I'm integrating Twilio in an elixir app to build the voice infrastructure for our company. I'm using the **task router** and, following the getting started guide, I found this snippet:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<Response>
  <Enqueue workflowSid="WW0123401234...">
    <Task>{"selected_language": "es"}</Task>
  </Enqueue>
</Response>
```

The enqueue tag is already there, while I can't find the task tag.

I've also added two tests, let me know if you think it's ok!
