### PR TITLE
Add "identity" and "parameter" verbs needed for dialing "client" with custom parameters

### DIFF
--- a/lib/ex_twiml.ex
+++ b/lib/ex_twiml.ex
@@ -75,10 +75,10 @@ defmodule ExTwiml do
 
     # Non-nested
     :say, :number, :play, :sms, :sip, :client, :conference, :queue, :enqueue,
-    :redirect, :body, :media
+    :redirect, :body, :media, :identity
   ]
 
-  @simple_verbs [:leave, :hangup, :reject, :pause, :record]
+  @simple_verbs [:leave, :hangup, :reject, :pause, :record, :parameter]
 
   @doc """
   Start creating a TwiML document. Returns the rendered TwiML as a string.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExTwiml.Mixfile do
   def project do
     [app: :ex_twiml,
      description: "Generate TwiML with Elixir",
-     version: "2.1.3",
+     version: "2.2.3",
      elixir: "~> 1.0",
      deps: deps(),
      dialyzer: [

--- a/test/ex_twiml_test.exs
+++ b/test/ex_twiml_test.exs
@@ -207,6 +207,34 @@ defmodule ExTwimlTest do
     assert_twiml markup, "<Media>https://demo.twilio.com/owl.png</Media>"
   end
 
+  test "can render the <Identity> verb" do
+    markup = twiml do
+      identity "emma_softphone_client"
+    end
+
+    assert_twiml markup, "<Identity>emma_softphone_client</Identity>"
+  end
+
+  test "can render the <Parameter> verb" do
+    markup = twiml do
+      parameter name: "neatNewParamKey", value: "neatNewParamValue"
+    end
+
+    assert_twiml markup, "<Parameter name=\"neatNewParamKey\" value=\"neatNewParamValue\" />"
+  end
+
+  test "can render the <Client> verb with <Identity> and <Param>s" do
+    markup = twiml do
+      client do
+        identity "emma_softphone_client"
+        parameter name: "neatNewParamKey", value: "neatNewParamValue"
+        parameter name: "neatNewParamKey2", value: "neatNewParamValue2"
+      end
+    end
+
+    assert_twiml markup, "<Client><Identity>emma_softphone_client</Identity><Parameter name=\"neatNewParamKey\" value=\"neatNewParamValue\" /><Parameter name=\"neatNewParamKey2\" value=\"neatNewParamValue2\" /></Client>"
+  end
+
   test ".twiml can include Enum loops" do
     markup = twiml do
       Enum.each 1..3, fn(n) ->


### PR DESCRIPTION
For details about `Identity` and `Parameter`, checkout the [Twilio docs for using Client](https://www.twilio.com/docs/voice/twiml/client#custom-parameters).